### PR TITLE
Add resume link, update 'hiring' line

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,9 +39,12 @@
               I'm primarily passionate about backend development, but my hardware background has made me excited, curious, and appreciative of the ways web technologies rely on our flexibility and creativity to build products. I'm seeking a place on a pragmatic team that loves shipping and learning, ideally in that order.
             </p>
             <p>
-              Are you hiring developers? Let's talk!
-              <br>
+              &#9758; Are you hiring developers? <strong>Let's talk!</strong>
+            </p>
+            <p>
               email: <a href="mail:thomasjeffreyng@gmail.com">thomasjeffreyng@gmail.com</a>
+              <br>
+              resume: <a href="https://resume.creddle.io/resume/cpf3lycv1ol" target="_blank">view resume</a>
             </p>
           </div>
 


### PR DESCRIPTION
# Changes

* Added link to Creddle resume published page
* Updated text around 'hiring' including a little hand icon, which is a built-in HTML entity. 
  [Hand icon HTML entity info](https://graphemica.com/%E2%98%9E)

# Screenshot

<img width="396" alt="screen shot 2019-01-22 at 1 25 26 pm" src="https://user-images.githubusercontent.com/15573141/51556825-36a8f880-1e49-11e9-8667-20a484d2684e.png">

